### PR TITLE
Add lookups for overlapping intervals

### DIFF
--- a/src/ds/IntervalTree.js
+++ b/src/ds/IntervalTree.js
@@ -122,14 +122,15 @@ export default class IntervalTree {
     if (arguments.length === 3) {
       node = arguments[2];
     }
-    if (node === null || node.max < begin) {
-      return overlaps;
-    }
-    overlaps.push(...this.overlap(begin, end, node.left));
     if (!(begin > node.high || node.low > end)) {
       overlaps.push(node.data);
     }
-    overlaps.push(...this.overlap(begin, end, node.right));
+    if (node.left && node.left.max > begin) {
+      overlaps.push(...this.overlap(begin, end, node.left));
+    }
+    else if (node.right) {
+      overlaps.push(...this.overlap(begin, end, node.right));
+    }
     return overlaps;
   }
 }

--- a/src/ds/IntervalTree.js
+++ b/src/ds/IntervalTree.js
@@ -108,4 +108,28 @@ export default class IntervalTree {
     }
     return overlaps;
   }
+
+  /**
+   * Find all intervals that overlap a certain interval.
+   *
+   * @param {Number} begin The start of the valid interval
+   * @param {Number} end The end of the valid interval
+   * @returns {*[]} An array of all values that overlap the given interval.
+   */
+  overlap(begin, end) {
+    const overlaps = [];
+    let node = this._root;
+    if (arguments.length === 3) {
+      node = arguments[2];
+    }
+    if (node === null || node.max < begin) {
+      return overlaps;
+    }
+    overlaps.push(...this.overlap(begin, end, node.left));
+    if (!(begin > node.high || node.low > end)) {
+      overlaps.push(node.data);
+    }
+    overlaps.push(...this.overlap(begin, end, node.right));
+    return overlaps;
+  }
 }

--- a/test/ds/IntervalTree_test.js
+++ b/test/ds/IntervalTree_test.js
@@ -28,4 +28,21 @@ describe('DS - IntervalTree', () => {
     intervalTree.insert(0, 10, 'd');
     intervalTree.lookup(8).should.deep.equal(['d']);
   });
+
+  it ('should find overlapping intervals', () => {
+    const intervalTree = new IntervalTree();
+    intervalTree.insert(2, 4, 'a');
+    intervalTree.insert(2, 5, 'b');
+    intervalTree.insert(4, 6, 'c');
+    intervalTree.overlap(0, 1).should.deep.equal([]);
+    intervalTree.overlap(1, 2).should.deep.equal(['a', 'b']);
+    intervalTree.overlap(2, 3).should.deep.equal(['a', 'b']);
+    intervalTree.overlap(3, 4).should.deep.equal(['a', 'b', 'c']);
+    intervalTree.overlap(4, 5).should.deep.equal(['a', 'b', 'c']);
+    intervalTree.overlap(5, 6).should.deep.equal(['b', 'c']);
+    intervalTree.overlap(6, 7).should.deep.equal(['c']);
+    intervalTree.overlap(7, 8).should.deep.equal([]);
+    intervalTree.overlap(2, 6).should.deep.equal(['a', 'b', 'c']);
+    intervalTree.overlap(0, 8).should.deep.equal(['a', 'b', 'c']);
+  })
 });


### PR DESCRIPTION
We have a need to return all values which overlap a certain interval, which I think is a fairly common operation to run over an interval tree.