### PR TITLE
Fixed not descending the right side of the tree

### DIFF
--- a/src/ds/IntervalTree.js
+++ b/src/ds/IntervalTree.js
@@ -128,7 +128,7 @@ export default class IntervalTree {
     if (node.left && node.left.max > begin) {
       overlaps.push(...this.overlap(begin, end, node.left));
     }
-    else if (node.right) {
+    if (node.right && node.right.max > begin) {
       overlaps.push(...this.overlap(begin, end, node.right));
     }
     return overlaps;


### PR DESCRIPTION
Hi, 

I think I spotted a bug in the overlap code.

I think that if the algorithm thinks that there's a matching interval in the left branch, it doesn't look in the right branch, but it seems like that's an invalid assumption. 

Not 100% sure what test is needed to catch this failure.