### PR TITLE
Overlap intervals method doesn't descend into all possible subtrees

### DIFF
--- a/src/ds/IntervalTree.js
+++ b/src/ds/IntervalTree.js
@@ -4,6 +4,8 @@
  *
  * @property {Number} low Start of the interval
  * @property {Number} high End of the interval
+ * @property {Number} min The lowest endpoint of this node's interval or any of
+ * its children.
  * @property {Number} max The greatest endpoint of this node's interval or any
  * of its children.
  * @property {*} data The value of the interval
@@ -16,6 +18,7 @@ class IntervalTreeNode {
   constructor(low, high, data, parent) {
     this.low = low;
     this.high = high;
+    this.min = low;
     this.max = high;
     this.data = data;
     this.left = null;
@@ -68,6 +71,7 @@ export default class IntervalTree {
         : 'right';
       newNode = this._insert(begin, end, value, node[side], node, side);
       node.max = Math.max(node.max, newNode.max);
+      node.min = Math.min(node.min, newNode.min);
     }
     return newNode;
   }
@@ -128,7 +132,7 @@ export default class IntervalTree {
     if (node.left && node.left.max >= begin) {
       overlaps.push(...this.overlap(begin, end, node.left));
     }
-    if (node.right && node.right.low <= end) {
+    if (node.right && node.right.min <= end) {
       overlaps.push(...this.overlap(begin, end, node.right));
     }
     return overlaps;

--- a/test/ds/IntervalTree_test.js
+++ b/test/ds/IntervalTree_test.js
@@ -56,5 +56,11 @@ describe('DS - IntervalTree', () => {
     intervalTreeC.insert(4, 6, 'c');
     intervalTreeC.overlap(0, 5).should.deep.equal(['a', 'b', 'c']);
     intervalTreeC.overlap(3, 5).should.deep.equal(['a', 'b', 'c']);
+
+    const intervalTreeD = new IntervalTree();
+    intervalTreeD.insert(0, 4, 'a');
+    intervalTreeD.insert(3, 4, 'b');
+    intervalTreeD.insert(1, 2, 'c');
+    intervalTreeD.overlap(0, 2).should.deep.equal(['a', 'c']);
   });
 });


### PR DESCRIPTION
Following on from my latest comments in #4 here's a test case that shows the issue.
If you re-order the insertions in this test, then it'll pass, so this really should pass.